### PR TITLE
Add exclusion for consider-using-enumerate

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -90,7 +90,8 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         too-many-public-methods,
-        unsubscriptable-object
+        unsubscriptable-object,
+        consider-using-enumerate
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
Add a pylint exclusion for consider-using-enumerate. Not sure why pylint has an issue with you _not_ using enumerate, but I disagree.