### PR TITLE
Adding error catching for waypoint move to, so the drone won't stop while running waypoints

### DIFF
--- a/state_machine/states/impl/waypoint_impl.py
+++ b/state_machine/states/impl/waypoint_impl.py
@@ -7,6 +7,8 @@ from typing import Final
 import mavsdk.telemetry
 import utm
 
+from mavsdk.action import ActionError, ActionResult
+
 from flight.extract_gps import extract_gps, GPSData
 from flight.extract_gps import (
     WaypointUtm as WaylistUtm,
@@ -123,7 +125,10 @@ async def run(self: Waypoint) -> State:
                 # Gradually move toward goal altitude
                 curr_altitude += altitude_slope * line_segment.length()
 
-                await move_to(self.drone.system, lat_deg, lon_deg, curr_altitude, 1.0)
+                try:
+                    await move_to(self.drone.system, lat_deg, lon_deg, curr_altitude, 1.0)
+                except ActionError:
+                    logging.warning(ActionResult.Result.TIMEOUT)
 
             # use 0.9 for fast_param to get within 25 ft of waypoint with plenty of leeway
             # while being fast (values above 5/6 and less than 1 check for lat and lon with

--- a/state_machine/states/impl/waypoint_impl.py
+++ b/state_machine/states/impl/waypoint_impl.py
@@ -126,7 +126,7 @@ async def run(self: Waypoint) -> State:
                 curr_altitude += altitude_slope * line_segment.length()
 
                 try:
-                    await move_to(self.drone.system, lat_deg, lon_deg, curr_altitude, .83)
+                    await move_to(self.drone.system, lat_deg, lon_deg, curr_altitude, 0.83)
                 except ActionError:
                     logging.warning(ActionError)
 

--- a/state_machine/states/impl/waypoint_impl.py
+++ b/state_machine/states/impl/waypoint_impl.py
@@ -126,7 +126,7 @@ async def run(self: Waypoint) -> State:
                 curr_altitude += altitude_slope * line_segment.length()
 
                 try:
-                    await move_to(self.drone.system, lat_deg, lon_deg, curr_altitude, 1.0)
+                    await move_to(self.drone.system, lat_deg, lon_deg, curr_altitude, .83)
                 except ActionError:
                     logging.warning(ActionError)
 

--- a/state_machine/states/impl/waypoint_impl.py
+++ b/state_machine/states/impl/waypoint_impl.py
@@ -7,7 +7,7 @@ from typing import Final
 import mavsdk.telemetry
 import utm
 
-from mavsdk.action import ActionError, ActionResult
+from mavsdk.action import ActionError
 
 from flight.extract_gps import extract_gps, GPSData
 from flight.extract_gps import (
@@ -128,7 +128,7 @@ async def run(self: Waypoint) -> State:
                 try:
                     await move_to(self.drone.system, lat_deg, lon_deg, curr_altitude, 1.0)
                 except ActionError:
-                    logging.warning(ActionResult.Result.TIMEOUT)
+                    logging.warning(ActionError)
 
             # use 0.9 for fast_param to get within 25 ft of waypoint with plenty of leeway
             # while being fast (values above 5/6 and less than 1 check for lat and lon with


### PR DESCRIPTION
Catching logging and ignoring the errors from the move_to in waypoint state. To hopefully allow the drone to continue running without stopping.